### PR TITLE
Updates Docsy to 0.15.0, enables agent support

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -25,3 +25,4 @@ languageSettings:
 words:
   - CNCF
   - Docsy
+  - llms

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Docsy starter
 description: A Docsy-themed website template for technical documentation
-outputs:
-  - HTML
-  - REDIRECTS # Include this `content/en` ONLY
 params:
   body_class: td-navbar-links-all-active
   show_banner: true

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -23,8 +23,12 @@ outputFormats:
     notAlternative: true
 
 outputs:
-  home: [HTML]
-  section: [HTML]
+  # We define REDIRECTS here so all home outputs stay in one place (rather than
+  # overriding in each site-language index file). Netlify only processes the
+  # default-language _redirects file, the others are ignored.
+  home: [HTML, markdown, LLMS, REDIRECTS]
+  page: [HTML, markdown]
+  section: [HTML, markdown]
 
 #
 # Language settings
@@ -61,7 +65,7 @@ markup:
 imaging:
   resampleFilter: CatmullRom # cspell:disable-line
   quality: 75
-  anchor: smart
+  anchor: Smart
 
 params:
   copyright:
@@ -117,7 +121,7 @@ params:
 
 module:
   hugoVersion:
-    min: 0.155.3
+    min: 0.157.0
   mounts:
     - source: content/en
       target: content

--- a/package.json
+++ b/package.json
@@ -41,27 +41,27 @@
     "test": "npm list docsy && npm run check:format && npm run check:links",
     "update:docsy:local": "npm run preupdate:docsy && npm install -D file:../docsy/docsy && npm list docsy",
     "update:docsy:main": "VERSION=main npm run update:docsy",
-    "update:docsy": "npm install -D google/docsy#${VERSION:-semver:0.14.1} && npm list docsy",
+    "update:docsy": "npm install -D google/docsy#${VERSION:-semver:0.15.0} && npm list docsy",
     "update:hugo": "npm install --save-exact -D hugo-extended@latest",
     "update:packages": "npx npm-check-updates --dep 'prod,dev,optional,peer' -u"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.21",
-    "cspell": "^9.0.2",
-    "docsy": "github:google/docsy#semver:0.14.1",
-    "hugo-extended": "0.155.3",
+    "autoprefixer": "^10.5.0",
+    "cspell": "^10.0.0",
+    "docsy": "github:google/docsy#semver:0.15.0",
+    "hugo-extended": "0.157.0",
     "postcss-cli": "^11.0.1",
-    "prettier": "^3.5.3"
+    "prettier": "^3.8.3"
   },
   "optionalDependencies": {
-    "netlify-cli": "^21.5.0",
-    "npm-check-updates": "^18.0.1"
+    "netlify-cli": "^26.0.0",
+    "npm-check-updates": "^22.1.0"
   },
   "enginesComment": "Ensure that engines.node value stays consistent with the project's .nvmrc",
   "engines": {
     "node": ">=24"
   },
-  "gitHubActionCacheKey": "2026-02-09 - refresh cache for Docsy and latest hugo-extended",
+  "gitHubActionCacheKey": "2026-05-03 - refresh cache for Docsy 0.15.0 and Hugo 0.157.0",
   "private": true,
   "prettier": {
     "proseWrap": "always",

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1,4 +1,36 @@
 {
+  "https://cncf-docsy-starter.netlify.app/blog/2024/hello/index.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-05-03T05:56:11.127646-04:00"
+  },
+  "https://cncf-docsy-starter.netlify.app/blog/index.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-05-03T05:56:11.093064-04:00"
+  },
+  "https://cncf-docsy-starter.netlify.app/community/index.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-05-03T05:56:11.047208-04:00"
+  },
+  "https://cncf-docsy-starter.netlify.app/docs/examples/index.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-05-03T05:56:11.035682-04:00"
+  },
+  "https://cncf-docsy-starter.netlify.app/docs/get-started/index.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-05-03T05:56:11.090435-04:00"
+  },
+  "https://cncf-docsy-starter.netlify.app/docs/index.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-05-03T05:56:11.1427-04:00"
+  },
+  "https://cncf-docsy-starter.netlify.app/index.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-05-03T05:56:11.076561-04:00"
+  },
+  "https://cncf-docsy-starter.netlify.app/search/index.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-05-03T05:56:11.10729-04:00"
+  },
   "https://code.jquery.com/jquery-3.7.1.min.js": {
     "StatusCode": 206,
     "LastSeen": "2026-02-06T17:17:02.950108-05:00"


### PR DESCRIPTION
- Updates Docsy, Hugo, and npm tooling so the starter tracks the supported 0.15.0 release baseline.
- Enables Markdown alternates and llms.txt so agents and automated tools can discover and consume site content.
- Centralizes homepage output configuration so Netlify redirects and agent-facing outputs stay in one place.
- Refreshes validation metadata and spelling config for the newly generated Markdown URLs.